### PR TITLE
Release/trigger v5 tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,13 @@ on:
       - '5.0/**'
       - 'docker/**'
       - 'Makefile'
+      - '.github/workflows/main.yml'
   pull_request:
     paths:
       - '5.0/**'
       - 'docker/**'
       - 'Makefile'
+      - '.github/workflows/main.yml'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         LATEST_TAG=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
         if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" == "null" ]; then
-          LATEST_TAG="v5.0.0"
+          LATEST_TAG=""
         fi
         echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
 
@@ -62,10 +62,19 @@ jobs:
       if: github.event_name == 'push'
       run: |
         LATEST_TAG=${{ env.LATEST_TAG }}
-        LATEST_VERSION=${LATEST_TAG#v}
-        IFS='.' read -r major minor patch <<< "$LATEST_VERSION"
-        NEW_VERSION="$major.$minor.$((patch + 1))"
-        NEW_TAG="v$NEW_VERSION"
+
+        # TCASVS release line is anchored to ASVS-style v5.x tags.
+        # Ignore legacy TASVS tags (for example v1.8.x) when deriving the next tag.
+        if [[ "$LATEST_TAG" =~ ^v5\.([0-9]+)\.([0-9]+)$ ]]; then
+          major=5
+          minor=${BASH_REMATCH[1]}
+          patch=${BASH_REMATCH[2]}
+          NEW_VERSION="$major.$minor.$((patch + 1))"
+          NEW_TAG="v$NEW_VERSION"
+        else
+          NEW_TAG="v5.0.0"
+        fi
+
         echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
 
     - name: Create GitHub Release

--- a/index.md
+++ b/index.md
@@ -54,6 +54,6 @@ The OWASP TCASVS would like to thank all of our [contributors](https://github.co
   </a>
 </p>
 
-**Bentley is the leading provider of infrastructure engineering software, advancing infrastructure for better quality of life and sustainability.**
+**Bentley Systems is the leading provider of infrastructure engineering software, advancing infrastructure for better quality of life and sustainability.**
 
 Visit [bentley.com](https://www.bentley.com/company/about-us/) to learn more.


### PR DESCRIPTION
The root cause
The release workflow in main.yml derives the next version by reading the latest GitHub release tag and bumping the patch number. Because the repo still had a legacy v1.8.0 TASVS tag, the merge of PR #36 produced v1.8.1 instead of 5.0.0.

Fix 1 — version guard main.yml
The workflow now only increments when the latest tag matches v5.x. Any other case (legacy v1.8.x or no tag) produces v5.0.0. So legacy TASVS tags can no longer drive TCASVS versioning.

Fix 2 — trigger path main.yml
The workflow only ran on changes under 5.0/**, docker/**, or Makefile. I added .github/workflows/main.yml to the trigger paths so merging this fix actually runs the release job.